### PR TITLE
fix: docker compose up d 제거

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -67,9 +67,6 @@ jobs:
             sudo docker stop ipsidori || true
             sudo docker rm ipsidori || true
 
-            # docker-compose로 인프라 서비스 실행 (네트워크 자동 생성)
-            sudo docker-compose up -d
-
             # 백엔드 컨테이너 실행
             sudo docker run -d \
               --name ipsidori \


### PR DESCRIPTION
### #️⃣ 연관된 이슈 (Issue)
#32

### 🔀 반영 브랜치
fix/#32-cicd-docker-compose-up--d-remove -> develop

### 📝 요약 (Summary)
docker-compose up -d 제거

### 💬 공유사항 to 리뷰어
`docker-compose up -d`는 docker-compose.yml의 모든 서비스(nginx, mariadb, certbot)를 시작하는 명령어입니다.
현재 EC2에서 인프라 서비스들이 이미 실행 중인데, CICD에서 이 명령어를 실행하면 기존 컨테이너와 이름 충돌이 발생하여 배포가 실패합니다.
따라서 CICD에서는 백엔드 애플리케이션만 업데이트하도록 `docker-compose up -d`를 제거했습니다.

### ✅ PR Checklist
<!--- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 코드 & 커밋 컨벤션에 맞게 작성했습니다.
- [ ] 관련된 테스트 코드 작성 or 기존 테스트 통과를 완료했습니다.
- [ ] 불필요한 로그, 주석, TODO를 제거했습니다.