### PR TITLE
feat: 카카오 로그인 엔드포인트 추가

### DIFF
--- a/src/main/java/com/server/dori/domain/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/server/dori/domain/auth/presentation/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.server.dori.domain.auth.presentation.controller;
 
+import java.io.IOException;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -21,6 +23,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +33,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 	private final QueryAuthService queryAuthService;
+
+	@Operation(summary = "카카오 로그인 시작", description = "카카오 OAuth2 로그인 페이지로 리다이렉트합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "302", description = "카카오 로그인 페이지로 리다이렉트")
+	})
+	@GetMapping("/oauth2/authorization/kakao")
+	public void kakaoLoginStart(HttpServletResponse response) throws IOException {
+		response.sendRedirect("/oauth2/authorization/kakao");
+	}
 
 	@Operation(summary = "카카오 소셜 로그인 (전체 플로우 처리)")
 	@ApiResponses({

--- a/src/main/java/com/server/dori/domain/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/server/dori/domain/auth/presentation/controller/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController {
 		response.sendRedirect("/oauth2/authorization/kakao");
 	}
 
-	@Operation(summary = "카카오 소셜 로그인 (전체 플로우 처리)")
+	@Operation(summary = "카카오 소셜 로그인 콜백", description = "카카오 OAuth2 인증 완료 후 호출되는 콜백 엔드포인트입니다. JWT 토큰을 발급받습니다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "로그인 성공, JWT 토큰 발급"),
 		@ApiResponse(responseCode = "404", description = "카카오 사용자 정보 없음")


### PR DESCRIPTION
### #️⃣ 연관된 이슈 (Issue)
#34

### 🔀 반영 브랜치
feat/#34-kakao-login-start-endpoint -> develop

### 📝 요약 (Summary)
프론트엔드가 스웨거에서 카카오 로그인 시작 엔드포인트를 보여줍니다.

### 💬 공유사항 to 리뷰어

### ✅ PR Checklist
<!--- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 코드 & 커밋 컨벤션에 맞게 작성했습니다.
- [ ] 관련된 테스트 코드 작성 or 기존 테스트 통과를 완료했습니다.
- [x] 불필요한 로그, 주석, TODO를 제거했습니다.