### PR TITLE
feat: 최초 회원가입 시, 수정 API 사용 못하도록 검증 코드 추가

### DIFF
--- a/src/main/java/com/server/dori/domain/member/service/CommandMemberService.java
+++ b/src/main/java/com/server/dori/domain/member/service/CommandMemberService.java
@@ -26,6 +26,7 @@ public class CommandMemberService {
 
 	public Member updateMemberInfo(Long memberId, MemberInfoUpdateDto requestDto) {
 		Member member = memberReader.getMember(memberId);
+		memberValidator.validateMemberCompleted(member);
 		return memberUpdater.updateInfo(member, requestDto);
 	}
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈 (Issue)
#31

### 🔀 반영 브랜치
fix/#31-최초회원가입-카카오-로그인-성공-이후-회원정보-put-사용-예외처리 -> develop

### 📝 요약 (Summary)
최초 회원가입 유저가 카카오 로그인만 했을 경우에는 회원정보가 없기 때문에 회원 정보 추가 입력하도록 예외처리 메시지를 전달합니다.

### 💬 공유사항 to 리뷰어

<img width="828" alt="image" src="https://github.com/user-attachments/assets/e9683741-8bc3-4f98-b174-c5d1df8b71d8" />


### ✅ PR Checklist
<!--- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 코드 & 커밋 컨벤션에 맞게 작성했습니다.
- [ ] 관련된 테스트 코드 작성 or 기존 테스트 통과를 완료했습니다.
- [ ] 불필요한 로그, 주석, TODO를 제거했습니다.