### PR TITLE
fix: cicd 스크립트의 env 위치 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,6 +72,6 @@ jobs:
               --name ipsidori \
               --network ipsidori_default \
               -p 8080:8080 \
-              --env-file ../src/main/resources/config/.env \
+              --env-file .env \
               --restart always \
               ${{env.DOCKER_IMAGE_NAME}}:latest


### PR DESCRIPTION
### #️⃣ 연관된 이슈 (Issue)
#37

### 🔀 반영 브랜치
fix/#37-cicd-update-script-about-env-folder -> develop -->

### 📝 요약 (Summary)
현재는 git pull로 소스 코드는 지워진 상태라서 해당 환경 변수 파일을 읽지 못하는 상황입니다.
하지만, 실제 배포 서버에서 확인해본 결과 기존 github 에서 받아온 소스 코드의 환경 변수를 참고하고 있었습니다.
`--env-file ../src/main/resources/config/.env \`

### 💬 공유사항 to 리뷰어
해당 PR이 develop에 머지되면, develop에서 main 브랜치로 머지되어야 도커 이미지가 업데이트될 것 같습니다.

### ✅ PR Checklist
<!--- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 코드 & 커밋 컨벤션에 맞게 작성했습니다.
- [ ] 관련된 테스트 코드 작성 or 기존 테스트 통과를 완료했습니다.
- [ ] 불필요한 로그, 주석, TODO를 제거했습니다.