### PR TITLE
fix: CI/CD 이미지 태그 전략 수정으로 배포 안정성 강화

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   build-and-push-docker:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_tag.outputs.tag }}
 
     steps:
       - name: Checkout
@@ -27,22 +29,30 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Set tag
+        id: set_tag
+        run: echo "tag=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
       - name: Pull the existing Docker image (if any)
         run: |
           docker pull ${{ env.DOCKER_IMAGE_NAME }}:latest || true
 
       - name: Build the Docker image with cache
         run: |
-          docker build . --file Dockerfile --tag ${{ env.DOCKER_IMAGE_NAME }}:latest \
-          --cache-from=${{ env.DOCKER_IMAGE_NAME }}:latest \
-          --platform linux/amd64
+          docker build . --file Dockerfile \
+            --tag ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.set_tag.outputs.tag }} \
+            --tag ${{ env.DOCKER_IMAGE_NAME }}:latest \
+            --cache-from=${{ env.DOCKER_IMAGE_NAME }}:latest \
+            --platform linux/amd64
 
       - name: Login to Docker Hub using Access Token
         run: |
           echo ${{ env.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
 
       - name: Push the Docker image
-        run: docker push ${{env.DOCKER_IMAGE_NAME}}:latest
+        run: |
+          docker push ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.set_tag.outputs.tag }}
+          docker push ${{ env.DOCKER_IMAGE_NAME }}:latest
 
   deploy-to-ec2:
     needs: build-and-push-docker
@@ -60,18 +70,17 @@ jobs:
             # docker-project 디렉토리로 이동
             cd docker-project
 
-            # 최신 백엔드 이미지 pull
-            sudo docker pull ${{env.DOCKER_IMAGE_NAME}}:latest
+            # 최신 백엔드 이미지 pull (고유 태그 사용)
+            sudo docker pull ${{env.DOCKER_IMAGE_NAME}}:${{ needs.build-and-push-docker.outputs.tag }}
 
             # 기존 백엔드 컨테이너만 정리 (인프라는 유지)
             sudo docker stop ipsidori || true
             sudo docker rm ipsidori || true
 
-            # 백엔드 컨테이너 실행
+            # 백엔드 컨테이너 실행 (고유 태그 사용)
             sudo docker run -d \
               --name ipsidori \
               --network ipsidori_default \
               -p 8080:8080 \
-              --env-file .env \
               --restart always \
-              ${{env.DOCKER_IMAGE_NAME}}:latest
+              ${{env.DOCKER_IMAGE_NAME}}:${{ needs.build-and-push-docker.outputs.tag }}


### PR DESCRIPTION
### #️⃣ 연관된 이슈 (Issue)
#42

### 🔀 반영 브랜치
fix/#42-infra-cicd-deploy-not-change-docker-image -> develop

### 📝 요약 (Summary)
latest 태그에 의존하던 기존 Docker 배포 방식은, **서버에서 캐시된 구버전 이미지를 재사용하여 최신 코드 변경사항이 누락되는 버그**를 유발했습니다.
이 문제를 해결하기 위해, **Git 커밋 해시(SHA)를 고유 태그로 사용하여** 배포 시 항상 정확한 버전의 이미지를 명시적으로 pull 하도록 cicd.yml을 수정했습니다.

### 💬 공유사항 to 리뷰어
#### **[기존 문제의 기술적 원인]**
EC2 Docker 데몬은 docker pull:latest 명령을 받으면, 원격 저장소(Docker Hub)를 확인하기 전에 로컬에 latest 태그가 있는지 먼저 봅니다. 로컬에 태그가 있으면, 최신 버전을 가졌다고 착각하고 다운로드를 건너뛰는 최적화 로직 때문에 저희의 배포가 누락되었습니다.

> 그럼에도 현재 스크립트에는 latest 가 존재하긴 합니다.
latest는 "가장 최신 버전"이 아니라, Docker가 붙여주는 "기본 별명"입니다.
이 "별명"은 가리키는 대상이 계속 바뀔 수 있기 때문에, 역할에 따라 명확히 구분해서 생각해야 합니다.
배포(Deploy) 시의 latest: 신뢰할 수 없는 이름표입니다.
배포에 사용하면, 서버가 "이 별명을 가진 낡은 이미지가 있네"라고 착각하고 새 버전을 무시하는 문제를 일으킵니다. 따라서 배포에는 절대 사용하면 안 됩니다.
빌드(Build) 시의 latest: 유용한 참고서입니다.
빌드 캐시로 사용하면, "가장 최근에 성공했던 빌드를 참고해서, 바뀐 부분만 새로 만들자"고 알려주어 빌드 속도를 높여주는 고마운 도구입니다.
**따라서, 정리하자면 latest는 배포의 신뢰성을 위해서는 피해야 할 대상이지만, 빌드의 속도를 위해서는 유용하게 쓸 수 있는 도구입니다.**

> gemini 기준으로는 위와 같이 답변 해주긴 합니다...! 
그래서 저도 조금 더 이해해보려고 아래 레퍼런스들 참고해보니 latest 태그가 문제 원인일 것 같다고 하네요..!!
결론적으로는 태그를 latest를 사용하지 않고, 깃허브 커밋으로 태그를 지정한다는 것 같습니다.


#### **"불변 이미지" 전략 도입**
이 문제를 해결하기 위해 "불변 이미지(Immutable Image)" 배포 전략을 도입합니다. 이는 한 번 만들어진 이미지는 절대 변하지 않는다는 원칙입니다.

**[참고 레퍼런스] - latest 태그를 피해야하는 이유**
- https://vsupalov.com/docker-latest-tag/
- https://www.inflearn.com/community/questions/1198345/docker-image-latest-%EC%B5%9C%EC%8B%A0%ED%99%94-%EA%B4%80%EB%A0%A8-%EB%AC%B8%EC%9D%98?srsltid=AfmBOoqRMxzzCX3yHq9rWVFHTThljb4q7XnQxuTh4dZGOl7UTH_X3GEM
- https://pixx.tistory.com/485

### ✅ PR Checklist
<!--- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 코드 & 커밋 컨벤션에 맞게 작성했습니다.
- [ ] 관련된 테스트 코드 작성 or 기존 테스트 통과를 완료했습니다.
- [ ] 불필요한 로그, 주석, TODO를 제거했습니다.