### PR TITLE
hotfix: HTTPS 환경에서 Swagger UI Mixed Content 에러 해결

### DIFF
--- a/src/main/java/com/server/dori/global/config/SwaggerConfig.java
+++ b/src/main/java/com/server/dori/global/config/SwaggerConfig.java
@@ -1,7 +1,9 @@
 package com.server.dori.global.config;
 
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,6 +16,9 @@ import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class SwaggerConfig {
+
+	@Value("${spring.profiles.active:dev}")
+	private String activeProfile;
 
 	@Bean
 	public OpenAPI openApi() {
@@ -32,13 +37,27 @@ public class SwaggerConfig {
 
 		SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
+		// 프로파일에 따른 서버 설정
+		List<Server> servers = getServersByProfile();
+
 		return new OpenAPI()
 			.info(info)
 			.components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
 			.addSecurityItem(securityRequirement)
-			.servers(Arrays.asList(
-				new Server().url("https://ipsidori.o-r.kr").description("Production Server (HTTPS)"),
+			.servers(servers);
+	}
+
+	private List<Server> getServersByProfile() {
+		if ("prod".equals(activeProfile)) {
+			// 프로덕션 : HTTPS
+			return Collections.singletonList(
+				new Server().url("https://ipsidori.o-r.kr").description("Production Server (HTTPS)")
+			);
+		} else {
+			// 개발/테스트: 로컬호스트
+			return Collections.singletonList(
 				new Server().url("http://localhost:8080").description("Local Development Server")
-			));
+			);
+		}
 	}
 }

--- a/src/main/java/com/server/dori/global/config/SwaggerConfig.java
+++ b/src/main/java/com/server/dori/global/config/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.server.dori.global.config;
 
+import java.util.Arrays;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,6 +10,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class SwaggerConfig {
@@ -32,6 +35,10 @@ public class SwaggerConfig {
 		return new OpenAPI()
 			.info(info)
 			.components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
-			.addSecurityItem(securityRequirement);
+			.addSecurityItem(securityRequirement)
+			.servers(Arrays.asList(
+				new Server().url("https://ipsidori.o-r.kr").description("Production Server (HTTPS)"),
+				new Server().url("http://localhost:8080").description("Local Development Server")
+			));
 	}
 }

--- a/src/main/java/com/server/dori/global/config/WebConfig.java
+++ b/src/main/java/com/server/dori/global/config/WebConfig.java
@@ -10,8 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/api/v1/**")
-			.allowedOrigins("https://localhost:3000",
-				"https://ipsidori.o-r.kr")
+			.allowedOrigins("http://localhost:3000", "http://localhost:8080", "https://ipsidori.o-r.kr")
 			.allowedMethods("GET", "POST", "PUT", "DELETE")
 			.allowedHeaders("*")
 			.allowCredentials(true); // 쿠키


### PR DESCRIPTION
### #️⃣ 연관된 이슈 (Issue)
#51

### 🔀 반영 브랜치
hotfix/#51-https-swagger-ui-mixed-content -> develop

### 📝 요약 (Summary)
프로덕션 환경에서 스웨거 접속 시 발생하던 Mixed Content 에러를 해결했습니다.
**문제** : HTTPS 페이지에서 HTTP API 요청으로 인한 브라우저 차단
**원인** : SwaggerConfig에 서버 설정이 없어서 Swagger UI가 자동으로 HTTP URL 생성
**해결** : 프로파일별 HTTPS/HTTP 서버 설정 추가

### 💬 공유사항 to 리뷰어
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/660ce112-188a-48cf-a614-680e701b4faa" />

**[변경사항]**
> SwaggerConfig: 프로파일별 서버 설정 추가 (.servers() 메서드)

WebConfig : 배포 서버 https CORS 추가
WebSecurityConfig : Swagger UI 경로 설정

**[결과]**
> 환경별 자동 설정으로 개발 편의성 향상

프로덕션 : HTTPS만 사용하여 Mixed Content 에러 해결
로컬 : localhost만 사용하여 실수로 프로덕션 API 호출 방지

[참고 레퍼런스] - Mixed Content
- https://hanjungyo.tistory.com/139

### ✅ PR Checklist
<!--- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 코드 & 커밋 컨벤션에 맞게 작성했습니다.
- [ ] 관련된 테스트 코드 작성 or 기존 테스트 통과를 완료했습니다.
- [x] 불필요한 로그, 주석, TODO를 제거했습니다.