### PR TITLE
Feat/#72 course api

### DIFF
--- a/src/main/java/com/server/dori/domain/course/entity/Course.java
+++ b/src/main/java/com/server/dori/domain/course/entity/Course.java
@@ -4,12 +4,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.server.dori.domain.course.entity.sub.Lecture;
+import com.server.dori.domain.course.service.implementation.CourseValidator;
+import com.server.dori.domain.member.entity.Member;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -26,8 +31,6 @@ public class Course {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
-	private String externalCourseId;
 
 	private String title;
 
@@ -48,11 +51,15 @@ public class Course {
 	@OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Lecture> lectureList = new ArrayList<>();
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member creator;
+
 	@Builder
-	public Course(Long id, String externalCourseId, String title, String description, String subject, String teacher,
+	public Course(Member creator, Long id, String title, String description, String subject, String teacher,
 		String grade, String platform, int price, String recommend) {
+		this.creator = creator;
 		this.id = id;
-		this.externalCourseId = externalCourseId;
 		this.title = title;
 		this.description = description;
 		this.subject = subject;
@@ -61,5 +68,11 @@ public class Course {
 		this.platform = platform;
 		this.price = price;
 		this.recommend = recommend;
+	}
+
+	public void addLecture(Lecture lecture, CourseValidator validator) {
+		validator.validateLectureCourseBinding(lecture);
+		lecture.assignCourse(this);
+		this.lectureList.add(lecture);
 	}
 }

--- a/src/main/java/com/server/dori/domain/course/entity/Course.java
+++ b/src/main/java/com/server/dori/domain/course/entity/Course.java
@@ -75,4 +75,8 @@ public class Course {
 		lecture.assignCourse(this);
 		this.lectureList.add(lecture);
 	}
+
+	public boolean isCreator(Long memberId) {
+		return this.creator.getId().equals(memberId);
+	}
 }

--- a/src/main/java/com/server/dori/domain/course/entity/Course.java
+++ b/src/main/java/com/server/dori/domain/course/entity/Course.java
@@ -1,9 +1,16 @@
 package com.server.dori.domain.course.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.server.dori.domain.course.entity.sub.Lecture;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,7 +25,9 @@ public class Course {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long courseId;
+	private Long id;
+
+	private String externalCourseId;
 
 	private String title;
 
@@ -36,10 +45,14 @@ public class Course {
 
 	private String recommend;
 
+	@OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Lecture> lectureList = new ArrayList<>();
+
 	@Builder
-	public Course(Long courseId, String title, String description, String subject, String teacher,
+	public Course(Long id, String externalCourseId, String title, String description, String subject, String teacher,
 		String grade, String platform, int price, String recommend) {
-		this.courseId = courseId;
+		this.id = id;
+		this.externalCourseId = externalCourseId;
 		this.title = title;
 		this.description = description;
 		this.subject = subject;

--- a/src/main/java/com/server/dori/domain/course/entity/Course.java
+++ b/src/main/java/com/server/dori/domain/course/entity/Course.java
@@ -56,10 +56,9 @@ public class Course {
 	private Member creator;
 
 	@Builder
-	public Course(Member creator, Long id, String title, String description, String subject, String teacher,
+	public Course(Member creator, String title, String description, String subject, String teacher,
 		String grade, String platform, int price, String recommend) {
 		this.creator = creator;
-		this.id = id;
 		this.title = title;
 		this.description = description;
 		this.subject = subject;

--- a/src/main/java/com/server/dori/domain/course/entity/sub/Lecture.java
+++ b/src/main/java/com/server/dori/domain/course/entity/sub/Lecture.java
@@ -1,0 +1,49 @@
+package com.server.dori.domain.course.entity.sub;
+
+import com.server.dori.domain.course.entity.Course;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "`lectures`")
+public class Lecture {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+
+	private String info;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "course_id")
+	private Course course;
+
+	@Builder
+	public Lecture(String title, String info) {
+		this.title = title;
+		this.info = info;
+	}
+
+	public boolean hasCourse() {
+		return this.course != null;
+	}
+
+	public void assignCourse(Course course) {
+		this.course = course;
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/exception/CourseNotAuthorException.java
+++ b/src/main/java/com/server/dori/domain/course/exception/CourseNotAuthorException.java
@@ -1,0 +1,11 @@
+package com.server.dori.domain.course.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.server.dori.global.response.exception.CustomException;
+
+public class CourseNotAuthorException extends CustomException {
+	public CourseNotAuthorException() {
+		super(HttpStatus.FORBIDDEN, "GRADE_403_1", "성적 생성자가 아닙니다.");
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/exception/CourseNotFoundException.java
+++ b/src/main/java/com/server/dori/domain/course/exception/CourseNotFoundException.java
@@ -1,0 +1,11 @@
+package com.server.dori.domain.course.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.server.dori.global.response.exception.CustomException;
+
+public class CourseNotFoundException extends CustomException {
+	public CourseNotFoundException() {
+		super(HttpStatus.NOT_FOUND, "COURSE_404_1", "해당 강의를 찾을 수 없습니다.");
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/presentation/CourseApiController.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/CourseApiController.java
@@ -1,0 +1,39 @@
+package com.server.dori.domain.course.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.server.dori.domain.course.presentation.dto.request.CourseRequest;
+import com.server.dori.domain.course.presentation.dto.response.CourseResponse;
+import com.server.dori.domain.curriculum.presentation.dto.request.CurriculumSurveyRequest;
+import com.server.dori.domain.curriculum.presentation.dto.response.CurriculumSurveyResponse;
+import com.server.dori.domain.member.entity.CustomUserDetails;
+import com.server.dori.global.response.CustomApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "강의", description = "강의 관련 API")
+@RequestMapping("/api/v1/course")
+public interface CourseApiController {
+
+	@Operation(summary = "강의 저장", description = "강의를 저장합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "강의 저장 성공",
+			content = @Content(schema = @Schema(implementation = CurriculumSurveyResponse.class))),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청")
+	})
+	@PostMapping
+	ResponseEntity<CustomApiResponse<CourseResponse>> createCourse(
+		@RequestBody CourseRequest request,
+		@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+	);
+}

--- a/src/main/java/com/server/dori/domain/course/presentation/CourseApiController.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/CourseApiController.java
@@ -1,20 +1,24 @@
 package com.server.dori.domain.course.presentation;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.server.dori.domain.course.presentation.dto.request.CourseRequest;
+import com.server.dori.domain.course.presentation.dto.response.CourseListResponse;
 import com.server.dori.domain.course.presentation.dto.response.CourseResponse;
-import com.server.dori.domain.curriculum.presentation.dto.request.CurriculumSurveyRequest;
 import com.server.dori.domain.curriculum.presentation.dto.response.CurriculumSurveyResponse;
 import com.server.dori.domain.member.entity.CustomUserDetails;
 import com.server.dori.global.response.CustomApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,6 +29,28 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RequestMapping("/api/v1/course")
 public interface CourseApiController {
 
+	@Operation(summary = "강의 전체 조회", description = "학생의 강의 정보를 전체 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "강의 전체 조회 성공",
+			content = @Content(schema = @Schema(implementation = CourseListResponse.class)))
+	})
+	@GetMapping
+	ResponseEntity<CustomApiResponse<List<CourseListResponse>>> getCourseList(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+
+	@Operation(summary = "강의 상세 조회", description = "특정 강의 Id로 강의 상세 정보를 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "강의 상세 조회 성공",
+			content = @Content(schema = @Schema(implementation = CourseResponse.class))),
+		@ApiResponse(responseCode = "404", description = "강의 없음")
+	})
+	@GetMapping("/{courseId}")
+	ResponseEntity<CustomApiResponse<CourseResponse>> getCourse(
+		@RequestParam(name = "courseId") Long courseId,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+
 	@Operation(summary = "강의 저장", description = "강의를 저장합니다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "강의 저장 성공",
@@ -34,6 +60,6 @@ public interface CourseApiController {
 	@PostMapping
 	ResponseEntity<CustomApiResponse<CourseResponse>> createCourse(
 		@RequestBody CourseRequest request,
-		@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	);
 }

--- a/src/main/java/com/server/dori/domain/course/presentation/CourseApiController.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/CourseApiController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -60,6 +61,18 @@ public interface CourseApiController {
 	@PostMapping
 	ResponseEntity<CustomApiResponse<CourseResponse>> createCourse(
 		@RequestBody CourseRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+
+	@Operation(summary = "강의 삭제", description = "강의를 삭제합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "204", description = "강의 삭제 성공",
+			content = @Content(schema = @Schema(implementation = CurriculumSurveyResponse.class))),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청")
+	})
+	@DeleteMapping
+	ResponseEntity<CustomApiResponse> deleteCourse(
+		@RequestParam(name = "courseId") Long courseId,
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	);
 }

--- a/src/main/java/com/server/dori/domain/course/presentation/CourseApiController.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/CourseApiController.java
@@ -66,8 +66,7 @@ public interface CourseApiController {
 
 	@Operation(summary = "강의 삭제", description = "강의를 삭제합니다.")
 	@ApiResponses({
-		@ApiResponse(responseCode = "204", description = "강의 삭제 성공",
-			content = @Content(schema = @Schema(implementation = CurriculumSurveyResponse.class))),
+		@ApiResponse(responseCode = "204", description = "강의 삭제 성공"),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청")
 	})
 	@DeleteMapping

--- a/src/main/java/com/server/dori/domain/course/presentation/CourseController.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/CourseController.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +16,6 @@ import com.server.dori.domain.course.service.QueryCourseService;
 import com.server.dori.domain.member.entity.CustomUserDetails;
 import com.server.dori.global.response.CustomApiResponse;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -51,5 +49,13 @@ public class CourseController implements CourseApiController{
 	) {
 		CourseResponse response = queryCourseService.getCourse(userDetails.getMemberId(), courseId);
 		return CustomApiResponse.ok(response);
+	}
+
+	public ResponseEntity<CustomApiResponse> deleteCourse(
+		@RequestParam(name = "courseId") Long courseId,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		commandCourseService.deleteCourse(userDetails.getMemberId(), courseId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/server/dori/domain/course/presentation/CourseController.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/CourseController.java
@@ -1,13 +1,19 @@
 package com.server.dori.domain.course.presentation;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.server.dori.domain.course.presentation.dto.request.CourseRequest;
+import com.server.dori.domain.course.presentation.dto.response.CourseListResponse;
 import com.server.dori.domain.course.presentation.dto.response.CourseResponse;
 import com.server.dori.domain.course.service.CommandCourseService;
+import com.server.dori.domain.course.service.QueryCourseService;
 import com.server.dori.domain.member.entity.CustomUserDetails;
 import com.server.dori.global.response.CustomApiResponse;
 
@@ -19,13 +25,31 @@ import lombok.RequiredArgsConstructor;
 public class CourseController implements CourseApiController{
 
 	private final CommandCourseService commandCourseService;
+	private final QueryCourseService queryCourseService;
 
 	@Override
 	public ResponseEntity<CustomApiResponse<CourseResponse>> createCourse(
 		@RequestBody CourseRequest request,
-		@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	){
 		CourseResponse response = commandCourseService.createCourse(request, userDetails.getMemberId());
+		return CustomApiResponse.ok(response);
+	}
+
+	@Override
+	public ResponseEntity<CustomApiResponse<List<CourseListResponse>>> getCourseList(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		List<CourseListResponse> response = queryCourseService.getCourseList(userDetails.getMemberId());
+		return CustomApiResponse.ok(response);
+	}
+
+	@Override
+	public ResponseEntity<CustomApiResponse<CourseResponse>> getCourse(
+		@RequestParam(name = "courseId") Long courseId,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		CourseResponse response = queryCourseService.getCourse(userDetails.getMemberId(), courseId);
 		return CustomApiResponse.ok(response);
 	}
 }

--- a/src/main/java/com/server/dori/domain/course/presentation/CourseController.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/CourseController.java
@@ -1,0 +1,31 @@
+package com.server.dori.domain.course.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.server.dori.domain.course.presentation.dto.request.CourseRequest;
+import com.server.dori.domain.course.presentation.dto.response.CourseResponse;
+import com.server.dori.domain.course.service.CommandCourseService;
+import com.server.dori.domain.member.entity.CustomUserDetails;
+import com.server.dori.global.response.CustomApiResponse;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class CourseController implements CourseApiController{
+
+	private final CommandCourseService commandCourseService;
+
+	@Override
+	public ResponseEntity<CustomApiResponse<CourseResponse>> createCourse(
+		@RequestBody CourseRequest request,
+		@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+	){
+		CourseResponse response = commandCourseService.createCourse(request, userDetails.getMemberId());
+		return CustomApiResponse.ok(response);
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/presentation/dto/request/CourseRequest.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/dto/request/CourseRequest.java
@@ -1,0 +1,26 @@
+package com.server.dori.domain.course.presentation.dto.request;
+
+import java.util.List;
+
+public record CourseRequest(
+	CourseDto recommendedCourse,
+	List<LectureDto> lectureList
+) {
+	public record CourseDto(
+		String courseId,
+		String title,
+		String description,
+		String subject,
+		String teacher,
+		String grade,
+		String platform,
+		boolean isPaid,
+		int price,
+		String recommend
+	) {}
+
+	public record LectureDto(
+		String title,
+		String info
+	) {}
+}

--- a/src/main/java/com/server/dori/domain/course/presentation/dto/request/CourseRequest.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/dto/request/CourseRequest.java
@@ -1,26 +1,57 @@
 package com.server.dori.domain.course.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "강의 등록 요청 DTO")
 public record CourseRequest(
+
+	@Schema(description = "추천 강의 정보")
 	CourseDto recommendedCourse,
+
+	@Schema(description = "강의 상세 목록")
 	List<LectureDto> lectureList
+
 ) {
+	@Schema(description = "추천 강의 DTO")
 	public record CourseDto(
+
+		@Schema(description = "강의 Id", example = "1")
 		String courseId,
+
+		@Schema(description = "강의 제목", example = "[2025 수능완성] 문학/비문학 - 홍길동전 (실전편)")
 		String title,
+
+		@Schema(description = "강의 설명", example = "문학·비문학 개념 완성 강의")
 		String description,
+
+		@Schema(description = "과목", example = "국어")
 		String subject,
+
+		@Schema(description = "강사명", example = "홍길동")
 		String teacher,
+
+		@Schema(description = "대상 학년", example = "고1")
 		String grade,
+
+		@Schema(description = "플랫폼", example = "EBSi")
 		String platform,
-		boolean isPaid,
+
+		@Schema(description = "가격", example = "0")
 		int price,
+
+		@Schema(description = "추천 대상 설명", example = "문학에 약한 학생에게 추천")
 		String recommend
 	) {}
 
+	@Schema(description = "강의(lecture) DTO")
 	public record LectureDto(
+
+		@Schema(description = "강의 제목", example = "1강 OT")
 		String title,
+
+		@Schema(description = "강의 정보", example = "수업 내용에 대한 오리엔테이션입니다.")
 		String info
 	) {}
 }

--- a/src/main/java/com/server/dori/domain/course/presentation/dto/response/CourseListResponse.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/dto/response/CourseListResponse.java
@@ -1,0 +1,25 @@
+package com.server.dori.domain.course.presentation.dto.response;
+
+import com.server.dori.domain.course.entity.Course;
+
+public record CourseListResponse(
+	Long id,
+	Long creator,
+	String title,
+	String subject,
+	String grade,
+	String platform,
+	int price
+) {
+	public static CourseListResponse of(Course course) {
+		return new CourseListResponse(
+			course.getId(),
+			course.getCreator().getId(),
+			course.getTitle(),
+			course.getSubject(),
+			course.getGrade(),
+			course.getPlatform(),
+			course.getPrice()
+		);
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/presentation/dto/response/CourseListResponse.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/dto/response/CourseListResponse.java
@@ -1,14 +1,30 @@
 package com.server.dori.domain.course.presentation.dto.response;
 
 import com.server.dori.domain.course.entity.Course;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "강의 리스트 응답 DTO")
 public record CourseListResponse(
+
+	@Schema(description = "강의 Id", example = "1")
 	Long id,
+
+	@Schema(description = "학생 Id", example = "10")
 	Long creator,
+
+	@Schema(description = "강의 제목", example = "문학/비문학 종합 강의")
 	String title,
+
+	@Schema(description = "과목", example = "국어")
 	String subject,
+
+	@Schema(description = "대상 학년", example = "고1")
 	String grade,
+
+	@Schema(description = "플랫폼", example = "EBSi")
 	String platform,
+
+	@Schema(description = "가격", example = "0")
 	int price
 ) {
 	public static CourseListResponse of(Course course) {

--- a/src/main/java/com/server/dori/domain/course/presentation/dto/response/CourseResponse.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/dto/response/CourseResponse.java
@@ -1,0 +1,55 @@
+package com.server.dori.domain.course.presentation.dto.response;
+
+import java.util.List;
+
+import com.server.dori.domain.course.entity.Course;
+
+public record CourseResponse(
+	Long id,
+	Long creator,
+	CourseDto recommendedCourse,
+	List<LectureDto> lectureList
+) {
+	public static CourseResponse of(Course course) {
+		CourseDto courseDto = new CourseDto(
+			course.getTitle(),
+			course.getDescription(),
+			course.getSubject(),
+			course.getTeacher(),
+			course.getGrade(),
+			course.getPlatform(),
+			course.getPrice(),
+			course.getRecommend()
+		);
+
+		List<LectureDto> lectures = course.getLectureList().stream()
+			.map(lecture -> new LectureDto(
+				lecture.getTitle(),
+				lecture.getInfo()
+			))
+			.toList();
+
+		return new CourseResponse(
+			course.getId(),
+			course.getCreator().getId(),
+			courseDto,
+			lectures
+		);
+	}
+
+	public record CourseDto(
+		String title,
+		String description,
+		String subject,
+		String teacher,
+		String grade,
+		String platform,
+		int price,
+		String recommend
+	) {}
+
+	public record LectureDto(
+		String title,
+		String info
+	) {}
+}

--- a/src/main/java/com/server/dori/domain/course/presentation/dto/response/CourseResponse.java
+++ b/src/main/java/com/server/dori/domain/course/presentation/dto/response/CourseResponse.java
@@ -3,11 +3,21 @@ package com.server.dori.domain.course.presentation.dto.response;
 import java.util.List;
 
 import com.server.dori.domain.course.entity.Course;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "강의 상세 응답 DTO")
 public record CourseResponse(
+
+	@Schema(description = "강의 Id", example = "1")
 	Long id,
+
+	@Schema(description = "생성자 회원 Id", example = "10")
 	Long creator,
+
+	@Schema(description = "추천 강의 정보")
 	CourseDto recommendedCourse,
+
+	@Schema(description = "강의 목록")
 	List<LectureDto> lectureList
 ) {
 	public static CourseResponse of(Course course) {
@@ -37,19 +47,41 @@ public record CourseResponse(
 		);
 	}
 
+	@Schema(description = "추천 강의 DTO")
 	public record CourseDto(
+
+		@Schema(description = "강의 제목", example = "문학/비문학 종합 강의")
 		String title,
+
+		@Schema(description = "강의 설명", example = "문학과 비문학을 아우르는 종합 강의입니다.")
 		String description,
+
+		@Schema(description = "과목", example = "국어")
 		String subject,
+
+		@Schema(description = "강사명", example = "홍길동")
 		String teacher,
+
+		@Schema(description = "대상 학년", example = "고1")
 		String grade,
+
+		@Schema(description = "플랫폼", example = "EBSi")
 		String platform,
+
+		@Schema(description = "가격", example = "0")
 		int price,
+
+		@Schema(description = "추천 대상 설명", example = "문학에 약한 학생에게 추천")
 		String recommend
 	) {}
 
+	@Schema(description = "강의(lecture) DTO")
 	public record LectureDto(
+
+		@Schema(description = "강의 제목", example = "1강 OT")
 		String title,
+
+		@Schema(description = "강의 정보", example = "수업 내용에 대한 오리엔테이션입니다.")
 		String info
 	) {}
 }

--- a/src/main/java/com/server/dori/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/server/dori/domain/course/repository/CourseRepository.java
@@ -1,8 +1,16 @@
 package com.server.dori.domain.course.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.server.dori.domain.course.entity.Course;
+import com.server.dori.domain.course.exception.CourseNotFoundException;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
+	default Course getById(Long courseId) {
+		return findById(courseId).orElseThrow(() -> new CourseNotFoundException());
+	}
+
+	List<Course> findAllByCreatorId(Long creatorId);
 }

--- a/src/main/java/com/server/dori/domain/course/service/CommandCourseService.java
+++ b/src/main/java/com/server/dori/domain/course/service/CommandCourseService.java
@@ -3,9 +3,13 @@ package com.server.dori.domain.course.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.server.dori.domain.course.entity.Course;
 import com.server.dori.domain.course.presentation.dto.request.CourseRequest;
 import com.server.dori.domain.course.presentation.dto.response.CourseResponse;
 import com.server.dori.domain.course.service.implementation.CourseCreator;
+import com.server.dori.domain.course.service.implementation.CourseDeleter;
+import com.server.dori.domain.course.service.implementation.CourseReader;
+import com.server.dori.domain.course.service.implementation.CourseValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,8 +19,17 @@ import lombok.RequiredArgsConstructor;
 public class CommandCourseService {
 
 	private final CourseCreator courseCreator;
+	private final CourseReader courseReader;
+	private final CourseValidator courseValidator;
+	private final CourseDeleter courseDeleter;
 
 	public CourseResponse createCourse(CourseRequest request, Long memberId) {
 		return CourseResponse.of(courseCreator.createCourse(request, memberId));
+	}
+
+	public void deleteCourse(Long memberId, Long courseId) {
+		Course course = courseReader.read(courseId);
+		courseValidator.checkCourseAuthor(course, memberId);
+		courseDeleter.delete(courseId);
 	}
 }

--- a/src/main/java/com/server/dori/domain/course/service/CommandCourseService.java
+++ b/src/main/java/com/server/dori/domain/course/service/CommandCourseService.java
@@ -1,0 +1,22 @@
+package com.server.dori.domain.course.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.server.dori.domain.course.presentation.dto.request.CourseRequest;
+import com.server.dori.domain.course.presentation.dto.response.CourseResponse;
+import com.server.dori.domain.course.service.implementation.CourseCreator;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommandCourseService {
+
+	private final CourseCreator courseCreator;
+
+	public CourseResponse createCourse(CourseRequest request, Long memberId) {
+		return CourseResponse.of(courseCreator.createCourse(request, memberId));
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/service/QueryCourseService.java
+++ b/src/main/java/com/server/dori/domain/course/service/QueryCourseService.java
@@ -23,7 +23,7 @@ public class QueryCourseService {
 
 	public CourseResponse getCourse(Long memberId, Long courseId) {
 		Course course = courseReader.read(courseId);
-		courseValidator.checkGradeAuthor(course, memberId);
+		courseValidator.checkCourseAuthor(course, memberId);
 		return CourseResponse.of(course);
 	}
 

--- a/src/main/java/com/server/dori/domain/course/service/QueryCourseService.java
+++ b/src/main/java/com/server/dori/domain/course/service/QueryCourseService.java
@@ -1,0 +1,36 @@
+package com.server.dori.domain.course.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.server.dori.domain.course.entity.Course;
+import com.server.dori.domain.course.presentation.dto.response.CourseListResponse;
+import com.server.dori.domain.course.presentation.dto.response.CourseResponse;
+import com.server.dori.domain.course.service.implementation.CourseReader;
+import com.server.dori.domain.course.service.implementation.CourseValidator;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QueryCourseService {
+
+	private final CourseValidator courseValidator;
+	private final CourseReader courseReader;
+
+	public CourseResponse getCourse(Long memberId, Long courseId) {
+		Course course = courseReader.read(courseId);
+		courseValidator.checkGradeAuthor(course, memberId);
+		return CourseResponse.of(course);
+	}
+
+	public List<CourseListResponse> getCourseList(Long memberId) {
+		List<Course> courses = courseReader.readAll(memberId);
+		return courses.stream()
+			.map(CourseListResponse::of)
+			.toList();
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/service/implementation/CourseCreator.java
+++ b/src/main/java/com/server/dori/domain/course/service/implementation/CourseCreator.java
@@ -1,0 +1,54 @@
+package com.server.dori.domain.course.service.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.server.dori.domain.course.entity.Course;
+import com.server.dori.domain.course.entity.sub.Lecture;
+import com.server.dori.domain.course.presentation.dto.request.CourseRequest;
+import com.server.dori.domain.course.repository.CourseRepository;
+import com.server.dori.domain.member.entity.Member;
+import com.server.dori.domain.member.exception.MemberNotFoundException;
+import com.server.dori.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CourseCreator {
+
+	private final MemberRepository memberRepository;
+	private final CourseValidator courseValidator;
+	private final CourseRepository courseRepository;
+
+	public Course createCourse(CourseRequest request, Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberNotFoundException());
+
+		CourseRequest.CourseDto courseDto = request.recommendedCourse();
+
+		Course course = Course.builder()
+			.id(member.getId())
+			.title(courseDto.title())
+			.description(courseDto.description())
+			.subject(courseDto.subject())
+			.teacher(courseDto.teacher())
+			.grade(courseDto.grade())
+			.platform(courseDto.platform())
+			.price(courseDto.price())
+			.recommend(courseDto.recommend())
+			.build();
+
+		List<CourseRequest.LectureDto> lectureDtoList = request.lectureList();
+		for (CourseRequest.LectureDto dto : lectureDtoList) {
+			Lecture lecture = Lecture.builder()
+				.title(dto.title())
+				.info(dto.info())
+				.build();
+			course.addLecture(lecture, courseValidator);
+		}
+
+		return courseRepository.save(course);
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/service/implementation/CourseCreator.java
+++ b/src/main/java/com/server/dori/domain/course/service/implementation/CourseCreator.java
@@ -29,7 +29,7 @@ public class CourseCreator {
 		CourseRequest.CourseDto courseDto = request.recommendedCourse();
 
 		Course course = Course.builder()
-			.id(member.getId())
+			.creator(member)
 			.title(courseDto.title())
 			.description(courseDto.description())
 			.subject(courseDto.subject())

--- a/src/main/java/com/server/dori/domain/course/service/implementation/CourseDeleter.java
+++ b/src/main/java/com/server/dori/domain/course/service/implementation/CourseDeleter.java
@@ -1,0 +1,18 @@
+package com.server.dori.domain.course.service.implementation;
+
+import org.springframework.stereotype.Service;
+
+import com.server.dori.domain.course.repository.CourseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CourseDeleter {
+
+	private final CourseRepository courseRepository;
+
+	public void delete(Long courseId) {
+		courseRepository.deleteById(courseId);
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/service/implementation/CourseReader.java
+++ b/src/main/java/com/server/dori/domain/course/service/implementation/CourseReader.java
@@ -1,0 +1,25 @@
+package com.server.dori.domain.course.service.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.server.dori.domain.course.entity.Course;
+import com.server.dori.domain.course.repository.CourseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CourseReader {
+
+	private final CourseRepository courseRepository;
+
+	public Course read(Long courseId) {
+		return courseRepository.getById(courseId);
+	}
+
+	public List<Course> readAll(Long memberId) {
+		return courseRepository.findAllByCreatorId(memberId);
+	}
+}

--- a/src/main/java/com/server/dori/domain/course/service/implementation/CourseValidator.java
+++ b/src/main/java/com/server/dori/domain/course/service/implementation/CourseValidator.java
@@ -2,13 +2,21 @@ package com.server.dori.domain.course.service.implementation;
 
 import org.springframework.stereotype.Service;
 
+import com.server.dori.domain.course.entity.Course;
 import com.server.dori.domain.course.entity.sub.Lecture;
+import com.server.dori.domain.course.exception.CourseNotAuthorException;
 
 @Service
 public class CourseValidator {
 	public void validateLectureCourseBinding(Lecture lecture) {
 		if (lecture.hasCourse()) {
 			throw new IllegalStateException("이미 Course에 할당된 Lecture입니다.");
+		}
+	}
+
+	public void checkGradeAuthor(Course course, Long memberId) {
+		if (!course.isCreator(memberId)) {
+			throw new CourseNotAuthorException();
 		}
 	}
 }

--- a/src/main/java/com/server/dori/domain/course/service/implementation/CourseValidator.java
+++ b/src/main/java/com/server/dori/domain/course/service/implementation/CourseValidator.java
@@ -14,7 +14,7 @@ public class CourseValidator {
 		}
 	}
 
-	public void checkGradeAuthor(Course course, Long memberId) {
+	public void checkCourseAuthor(Course course, Long memberId) {
 		if (!course.isCreator(memberId)) {
 			throw new CourseNotAuthorException();
 		}

--- a/src/main/java/com/server/dori/domain/course/service/implementation/CourseValidator.java
+++ b/src/main/java/com/server/dori/domain/course/service/implementation/CourseValidator.java
@@ -1,0 +1,14 @@
+package com.server.dori.domain.course.service.implementation;
+
+import org.springframework.stereotype.Service;
+
+import com.server.dori.domain.course.entity.sub.Lecture;
+
+@Service
+public class CourseValidator {
+	public void validateLectureCourseBinding(Lecture lecture) {
+		if (lecture.hasCourse()) {
+			throw new IllegalStateException("이미 Course에 할당된 Lecture입니다.");
+		}
+	}
+}

--- a/src/main/java/com/server/dori/domain/curriculum/presentation/CurriculumController.java
+++ b/src/main/java/com/server/dori/domain/curriculum/presentation/CurriculumController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.server.dori.domain.curriculum.presentation.dto.response.AICurriculumListResponse;
-import com.server.dori.domain.curriculum.presentation.dto.response.AICurriculumResponse;
 import com.server.dori.domain.curriculum.presentation.dto.request.CurriculumSurveyRequest;
 import com.server.dori.domain.curriculum.presentation.dto.response.CurriculumSurveyResponse;
 import com.server.dori.domain.curriculum.service.CommandCuriculumService;

--- a/src/main/java/com/server/dori/domain/curriculum/service/implementation/CurriculumCreator.java
+++ b/src/main/java/com/server/dori/domain/curriculum/service/implementation/CurriculumCreator.java
@@ -11,7 +11,6 @@ import com.server.dori.domain.curriculum.presentation.dto.response.AICurriculumL
 import com.server.dori.domain.curriculum.presentation.dto.response.AICurriculumResponse;
 import com.server.dori.domain.curriculum.presentation.dto.request.CurriculumSurveyRequest;
 import com.server.dori.domain.curriculum.entity.Curriculum;
-import com.server.dori.domain.curriculum.presentation.dto.response.CurriculumSurveyResponse;
 import com.server.dori.domain.curriculum.repository.CurriculumRepository;
 import com.server.dori.domain.grade.entity.Grade;
 import com.server.dori.domain.grade.repository.GradeRepository;

--- a/src/test/java/com/server/dori/course/entity/CourseTest.java
+++ b/src/test/java/com/server/dori/course/entity/CourseTest.java
@@ -15,8 +15,6 @@ import com.server.dori.domain.member.entity.Member;
 import com.server.dori.domain.member.entity.sub.Role;
 import com.server.dori.domain.member.entity.sub.SocialType;
 
-import lombok.SneakyThrows;
-
 class CourseTest {
 
 	@DisplayName("강의를 정상적으로 저장한다.")

--- a/src/test/java/com/server/dori/course/entity/CourseTest.java
+++ b/src/test/java/com/server/dori/course/entity/CourseTest.java
@@ -21,7 +21,6 @@ class CourseTest {
 	@Test
 	void testCourseBuilder() {
 		// given
-		Long id = 1L;
 		String title = "[2025 수능완성] 문학/비문학 - 홍길동전 (실전편)";
 		String description = "문학·비문학 개념 완성 강의";
 		String subject = "국어";
@@ -33,7 +32,6 @@ class CourseTest {
 
 		// when
 		Course course = Course.builder()
-			.id(id)
 			.title(title)
 			.description(description)
 			.subject(subject)
@@ -45,7 +43,6 @@ class CourseTest {
 			.build();
 
 		// then
-		assertThat(course.getId()).isEqualTo(id);
 		assertThat(course.getTitle()).isEqualTo(title);
 		assertThat(course.getDescription()).isEqualTo(description);
 		assertThat(course.getSubject()).isEqualTo(subject);

--- a/src/test/java/com/server/dori/course/entity/CourseTest.java
+++ b/src/test/java/com/server/dori/course/entity/CourseTest.java
@@ -97,10 +97,9 @@ class CourseTest {
 		assertThat(lecture.getCourse()).isEqualTo(course);
 	}
 
-	@SneakyThrows
 	@DisplayName("Course 생성자가 맞는지 확인한다.")
 	@Test
-	void testIsCreator() {
+	void testIsCreator() throws NoSuchFieldException, IllegalAccessException {
 		// given
 		Member member = Member.builder()
 			.email("test@example.com")

--- a/src/test/java/com/server/dori/course/entity/CourseTest.java
+++ b/src/test/java/com/server/dori/course/entity/CourseTest.java
@@ -14,7 +14,6 @@ class CourseTest {
 	void testCourseBuilder() {
 		// given
 		Long id = 1L;
-		String externalCourseId = "S20240000904";
 		String title = "[2025 수능완성] 문학/비문학 - 홍길동전 (실전편)";
 		String description = "문학·비문학 개념 완성 강의";
 		String subject = "국어";
@@ -27,7 +26,6 @@ class CourseTest {
 		// when
 		Course course = Course.builder()
 			.id(id)
-			.externalCourseId(externalCourseId)
 			.title(title)
 			.description(description)
 			.subject(subject)
@@ -40,7 +38,6 @@ class CourseTest {
 
 		// then
 		assertThat(course.getId()).isEqualTo(id);
-		assertThat(course.getExternalCourseId()).isEqualTo(externalCourseId);
 		assertThat(course.getTitle()).isEqualTo(title);
 		assertThat(course.getDescription()).isEqualTo(description);
 		assertThat(course.getSubject()).isEqualTo(subject);

--- a/src/test/java/com/server/dori/course/entity/CourseTest.java
+++ b/src/test/java/com/server/dori/course/entity/CourseTest.java
@@ -13,7 +13,8 @@ class CourseTest {
 	@Test
 	void testCourseBuilder() {
 		// given
-		Long courseId = 1L;
+		Long id = 1L;
+		String externalCourseId = "S20240000904";
 		String title = "[2025 수능완성] 문학/비문학 - 홍길동전 (실전편)";
 		String description = "문학·비문학 개념 완성 강의";
 		String subject = "국어";
@@ -25,7 +26,8 @@ class CourseTest {
 
 		// when
 		Course course = Course.builder()
-			.courseId(courseId)
+			.id(id)
+			.externalCourseId(externalCourseId)
 			.title(title)
 			.description(description)
 			.subject(subject)
@@ -37,7 +39,8 @@ class CourseTest {
 			.build();
 
 		// then
-		assertThat(course.getCourseId()).isEqualTo(courseId);
+		assertThat(course.getId()).isEqualTo(id);
+		assertThat(course.getExternalCourseId()).isEqualTo(externalCourseId);
 		assertThat(course.getTitle()).isEqualTo(title);
 		assertThat(course.getDescription()).isEqualTo(description);
 		assertThat(course.getSubject()).isEqualTo(subject);

--- a/src/test/java/com/server/dori/course/entity/sub/LectureTest.java
+++ b/src/test/java/com/server/dori/course/entity/sub/LectureTest.java
@@ -1,0 +1,72 @@
+package com.server.dori.course.entity.sub;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.server.dori.domain.course.entity.Course;
+import com.server.dori.domain.course.entity.sub.Lecture;
+import com.server.dori.domain.member.entity.Member;
+import com.server.dori.domain.member.entity.sub.Role;
+import com.server.dori.domain.member.entity.sub.SocialType;
+
+class LectureTest {
+
+	@DisplayName("강의가 정상적으로 매핑되는지 확인한다.")
+	@Test
+	void testLectureBuilder() {
+		// given
+		String title = "1강 - 고전소설 개념";
+		String info = "홍길동전 중심으로 배우는 고전소설 개념";
+
+		// when
+		Lecture lecture = Lecture.builder()
+			.title(title)
+			.info(info)
+			.build();
+
+		// then
+		assertThat(lecture.getTitle()).isEqualTo(title);
+		assertThat(lecture.getInfo()).isEqualTo(info);
+		assertThat(lecture.hasCourse()).isFalse();
+	}
+
+	@DisplayName("메서드로 강의에 과정을 할당할 수 있다.")
+	@Test
+	void testAssignCourse() throws Exception {
+		// given
+		Lecture lecture = Lecture.builder()
+			.title("1강 - 문학 개념")
+			.info("개념 정리 강의")
+			.build();
+
+		Member member = createMemberWithId(1L);
+		Course course = Course.builder()
+			.creator(member)
+			.title("테스트 강의")
+			.build();
+
+		// when
+		lecture.assignCourse(course);
+
+		// then
+		assertThat(lecture.hasCourse()).isTrue();
+		assertThat(lecture.getCourse()).isEqualTo(course);
+	}
+
+	private Member createMemberWithId(Long id) throws Exception {
+		Member member = Member.builder()
+			.email("test@example.com")
+			.role(Role.USER)
+			.socialType(SocialType.KAKAO)
+			.build();
+
+		Field idField = Member.class.getDeclaredField("id");
+		idField.setAccessible(true);
+		idField.set(member, id);
+		return member;
+	}
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈 (Issue)
#72 

### 🔀 반영 브랜치
feat/#72-course-api -> develop

### 📝 요약 (Summary)
- 강의를 저장할 수 있는 API를 만들었습니다.
- 학생의 강의(커리큘럼) 전체 조회 / 강의(커리큘럼) 상세 조회 API를 만들었습니다.
- 강의를 삭제할 수 있는 API를 만들었습니다.

### 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

### ✅ PR Checklist
<!--- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 코드 & 커밋 컨벤션에 맞게 작성했습니다.
- [x] 관련된 테스트 코드 작성 or 기존 테스트 통과를 완료했습니다.
- [x] 불필요한 로그, 주석, TODO를 제거했습니다.